### PR TITLE
Return an empty dict instead of None

### DIFF
--- a/fx_crash_sig/symbolicate.py
+++ b/fx_crash_sig/symbolicate.py
@@ -153,7 +153,7 @@ class Symbolicator:
         if trace is None:
             return {}
         symbolicated = self.symbolicate_multi([trace])
-        return symbolicated if symbolicated is None else symbolicated[0]
+        return {} if symbolicated is None else symbolicated[0]
 
     def symbolicate_multi(self, traces):
         """Symbolicate a list of crash traces


### PR DESCRIPTION
If we return None then the CrashProcessor can throw an exception while
trying to update the 'os' property on it.

(Note: I haven't actually tested this in the setup that I ran into the problem, because it's on a databricks cluster and I'm pulling this library from PyPi)